### PR TITLE
fixed incorrect name value in nomad plan

### DIFF
--- a/dp-observation-api.nomad
+++ b/dp-observation-api.nomad
@@ -106,7 +106,7 @@ job "dp-observation-api" {
       }
 
       service {
-        name = dp-observation-api
+        name = "dp-observation-api"
         port = "http"
         tags = ["publishing"]
 


### PR DESCRIPTION
Added missing string quotes to service name feild.
