### PR TITLE
Update healthcheck default configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ dp-observation-api
 | ---------------------------- | --------- | -----------
 | BIND_ADDR                    | :24500    | The host and port to bind to
 | GRACEFUL_SHUTDOWN_TIMEOUT    | 5s        | The graceful shutdown timeout in seconds (`time.Duration` format)
-| HEALTHCHECK_INTERVAL         | 10s       | Time between self-healthchecks (`time.Duration` format)
-| HEALTHCHECK_CRITICAL_TIMEOUT | 1m        | Time to wait until an unhealthy dependent propagates its state to make this app unhealthy (`time.Duration` format)
+| HEALTHCHECK_INTERVAL         | 30s       | Time between self-healthchecks (`time.Duration` format)
+| HEALTHCHECK_CRITICAL_TIMEOUT | 90s       | Time to wait until an unhealthy dependent propagates its state to make this app unhealthy (`time.Duration` format)
 
 ### Contributing
 

--- a/config/config.go
+++ b/config/config.go
@@ -1,8 +1,9 @@
 package config
 
 import (
-	"github.com/kelseyhightower/envconfig"
 	"time"
+
+	"github.com/kelseyhightower/envconfig"
 )
 
 // Config represents service configuration for dp-observation-api
@@ -25,8 +26,8 @@ func Get() (*Config, error) {
 	cfg := &Config{
 		BindAddr:                   ":24500",
 		GracefulShutdownTimeout:    5 * time.Second,
-		HealthCheckInterval:        10 * time.Second,
-		HealthCheckCriticalTimeout: time.Minute,
+		HealthCheckInterval:        30 * time.Second,
+		HealthCheckCriticalTimeout: 90 * time.Second,
 	}
 
 	return cfg, envconfig.Process("", cfg)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -19,7 +19,8 @@ func TestConfig(t *testing.T) {
 
 			Convey("Then the values should be set to the expected defaults", func() {
 				So(cfg.GracefulShutdownTimeout, ShouldEqual, 5*time.Second)
-				So(cfg.HealthCheckCriticalTimeout, ShouldEqual, 1*time.Minute)
+				So(cfg.HealthCheckInterval, ShouldEqual, 30*time.Second)
+				So(cfg.HealthCheckCriticalTimeout, ShouldEqual, 90*time.Second)
 				So(cfg.BindAddr, ShouldEqual, ":24500")
 			})
 


### PR DESCRIPTION
### What

See title

Health check interval changed to 30seconds and critical timeout set to 90 seconds

### How to review

- Check changes make sense
- Unit tests continue to pass

### Who can review

Nathan worked on changes, for anyone to review
