### PR TITLE
Feature/error handling

### DIFF
--- a/api/observation.go
+++ b/api/observation.go
@@ -11,7 +11,7 @@ import (
 	"strconv"
 	"strings"
 
-	dataset "github.com/ONSdigital/dp-api-clients-go/dataset"
+	"github.com/ONSdigital/dp-api-clients-go/dataset"
 	"github.com/ONSdigital/dp-graph/v2/observation"
 	"github.com/ONSdigital/dp-observation-api/apierrors"
 	errs "github.com/ONSdigital/dp-observation-api/apierrors"
@@ -23,8 +23,6 @@ import (
 
 const (
 	defaultOffset = 0
-
-	getObservationsAction = "getObservations"
 )
 
 var (
@@ -421,8 +419,8 @@ func createObservation(versionDoc *dataset.Version, observationRowArray, headerR
 func handleObservationsErrorType(ctx context.Context, w http.ResponseWriter, err error, data log.Data) {
 
 	_, isObservationErr := err.(apierrors.ObservationQueryError)
-
 	var status int
+	resErrMsg := err.Error()
 
 	switch {
 	case isObservationErr:
@@ -432,7 +430,7 @@ func handleObservationsErrorType(ctx context.Context, w http.ResponseWriter, err
 	case observationBadRequest[err]:
 		status = http.StatusBadRequest
 	default:
-		err = errs.ErrInternalServer
+		resErrMsg = errs.ErrInternalServer.Error()
 		status = http.StatusInternalServerError
 	}
 
@@ -442,5 +440,5 @@ func handleObservationsErrorType(ctx context.Context, w http.ResponseWriter, err
 
 	data["responseStatus"] = status
 	log.Event(ctx, "get observation endpoint: request unsuccessful", log.ERROR, log.Error(err), data)
-	http.Error(w, err.Error(), status)
+	http.Error(w, resErrMsg, status)
 }

--- a/config/config.go
+++ b/config/config.go
@@ -9,6 +9,7 @@ import (
 // Config represents service configuration for dp-observation-api
 type Config struct {
 	BindAddr                   string        `envconfig:"BIND_ADDR"`
+	HttpWriteTimeout           time.Duration `envconfig:"HTTP_WRITE_TIMEOUT"`
 	ServiceAuthToken           string        `envconfig:"SERVICE_AUTH_TOKEN"`
 	DatasetAPIURL              string        `envconfig:"DATASET_API_URL"`
 	ObservationAPIURL          string        `envconfig:"OBSERVATION_API_URL"`
@@ -31,6 +32,7 @@ func Get() (*Config, error) {
 
 	cfg := &Config{
 		BindAddr:                   ":24500",
+		HttpWriteTimeout:           60 * time.Second,
 		ServiceAuthToken:           "",
 		DatasetAPIURL:              "http://localhost:22000",
 		ObservationAPIURL:          "http://localhost:24500",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -20,6 +20,7 @@ func TestConfig(t *testing.T) {
 			Convey("Then the values should be set to the expected defaults", func() {
 				So(cfg, ShouldResemble, &Config{
 					BindAddr:                   ":24500",
+					HttpWriteTimeout:           60 * time.Second,
 					ServiceAuthToken:           "",
 					DatasetAPIURL:              "http://localhost:22000",
 					ObservationAPIURL:          "http://localhost:24500",

--- a/service/initialise.go
+++ b/service/initialise.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"net/http"
+	"time"
 
 	"github.com/ONSdigital/dp-graph/v2/graph"
 	"github.com/ONSdigital/dp-healthcheck/healthcheck"
@@ -32,8 +33,8 @@ func NewServiceList(initialiser Initialiser) *ExternalServiceList {
 type Init struct{}
 
 // GetHTTPServer creates an http server and sets the Server flag to true
-func (e *ExternalServiceList) GetHTTPServer(bindAddr string, router http.Handler) IServer {
-	s := e.Init.DoGetHTTPServer(bindAddr, router)
+func (e *ExternalServiceList) GetHTTPServer(bindAddr string, httpWriteTimeout time.Duration, router http.Handler) IServer {
+	s := e.Init.DoGetHTTPServer(bindAddr, httpWriteTimeout, router)
 	e.HTTPServer = true
 	return s
 }
@@ -59,8 +60,9 @@ func (e *ExternalServiceList) GetHealthCheck(cfg *config.Config, buildTime, gitC
 }
 
 // DoGetHTTPServer creates an HTTP Server with the provided bind address and router
-func (e *Init) DoGetHTTPServer(bindAddr string, router http.Handler) IServer {
+func (e *Init) DoGetHTTPServer(bindAddr string, httpWriteTimeout time.Duration, router http.Handler) IServer {
 	s := dpHTTP.NewServer(bindAddr, router)
+	s.WriteTimeout = httpWriteTimeout
 	s.HandleOSSignals = false
 	return s
 }

--- a/service/interfaces.go
+++ b/service/interfaces.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"net/http"
+	"time"
 
 	"github.com/ONSdigital/dp-healthcheck/healthcheck"
 	"github.com/ONSdigital/dp-observation-api/api"
@@ -16,7 +17,7 @@ import (
 
 // Initialiser defines the methods to initialise external services
 type Initialiser interface {
-	DoGetHTTPServer(bindAddr string, router http.Handler) IServer
+	DoGetHTTPServer(bindAddr string, httpWriteTimeout time.Duration, router http.Handler) IServer
 	DoGetGraphDB(ctx context.Context) (api.IGraph, Closer, error)
 	DoGetHealthCheck(cfg *config.Config, buildTime, gitCommit, version string) (IHealthCheck, error)
 }

--- a/service/mock/initialiser.go
+++ b/service/mock/initialiser.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ONSdigital/dp-observation-api/service"
 	"net/http"
 	"sync"
+	"time"
 )
 
 // Ensure, that InitialiserMock does implement service.Initialiser.
@@ -25,7 +26,7 @@ var _ service.Initialiser = &InitialiserMock{}
 //             DoGetGraphDBFunc: func(ctx context.Context) (api.IGraph, service.Closer, error) {
 // 	               panic("mock out the DoGetGraphDB method")
 //             },
-//             DoGetHTTPServerFunc: func(bindAddr string, router http.Handler) service.IServer {
+//             DoGetHTTPServerFunc: func(bindAddr string, httpWriteTimeout time.Duration, router http.Handler) service.IServer {
 // 	               panic("mock out the DoGetHTTPServer method")
 //             },
 //             DoGetHealthCheckFunc: func(cfg *config.Config, buildTime string, gitCommit string, version string) (service.IHealthCheck, error) {
@@ -42,7 +43,7 @@ type InitialiserMock struct {
 	DoGetGraphDBFunc func(ctx context.Context) (api.IGraph, service.Closer, error)
 
 	// DoGetHTTPServerFunc mocks the DoGetHTTPServer method.
-	DoGetHTTPServerFunc func(bindAddr string, router http.Handler) service.IServer
+	DoGetHTTPServerFunc func(bindAddr string, httpWriteTimeout time.Duration, router http.Handler) service.IServer
 
 	// DoGetHealthCheckFunc mocks the DoGetHealthCheck method.
 	DoGetHealthCheckFunc func(cfg *config.Config, buildTime string, gitCommit string, version string) (service.IHealthCheck, error)
@@ -58,6 +59,8 @@ type InitialiserMock struct {
 		DoGetHTTPServer []struct {
 			// BindAddr is the bindAddr argument value.
 			BindAddr string
+			// HttpWriteTimeout is the httpWriteTimeout argument value.
+			HttpWriteTimeout time.Duration
 			// Router is the router argument value.
 			Router http.Handler
 		}
@@ -110,33 +113,37 @@ func (mock *InitialiserMock) DoGetGraphDBCalls() []struct {
 }
 
 // DoGetHTTPServer calls DoGetHTTPServerFunc.
-func (mock *InitialiserMock) DoGetHTTPServer(bindAddr string, router http.Handler) service.IServer {
+func (mock *InitialiserMock) DoGetHTTPServer(bindAddr string, httpWriteTimeout time.Duration, router http.Handler) service.IServer {
 	if mock.DoGetHTTPServerFunc == nil {
 		panic("InitialiserMock.DoGetHTTPServerFunc: method is nil but Initialiser.DoGetHTTPServer was just called")
 	}
 	callInfo := struct {
-		BindAddr string
-		Router   http.Handler
+		BindAddr         string
+		HttpWriteTimeout time.Duration
+		Router           http.Handler
 	}{
-		BindAddr: bindAddr,
-		Router:   router,
+		BindAddr:         bindAddr,
+		HttpWriteTimeout: httpWriteTimeout,
+		Router:           router,
 	}
 	mock.lockDoGetHTTPServer.Lock()
 	mock.calls.DoGetHTTPServer = append(mock.calls.DoGetHTTPServer, callInfo)
 	mock.lockDoGetHTTPServer.Unlock()
-	return mock.DoGetHTTPServerFunc(bindAddr, router)
+	return mock.DoGetHTTPServerFunc(bindAddr, httpWriteTimeout, router)
 }
 
 // DoGetHTTPServerCalls gets all the calls that were made to DoGetHTTPServer.
 // Check the length with:
 //     len(mockedInitialiser.DoGetHTTPServerCalls())
 func (mock *InitialiserMock) DoGetHTTPServerCalls() []struct {
-	BindAddr string
-	Router   http.Handler
+	BindAddr         string
+	HttpWriteTimeout time.Duration
+	Router           http.Handler
 } {
 	var calls []struct {
-		BindAddr string
-		Router   http.Handler
+		BindAddr         string
+		HttpWriteTimeout time.Duration
+		Router           http.Handler
 	}
 	mock.lockDoGetHTTPServer.RLock()
 	calls = mock.calls.DoGetHTTPServer

--- a/service/service.go
+++ b/service/service.go
@@ -33,7 +33,7 @@ func Run(ctx context.Context, cfg *config.Config, serviceList *ExternalServiceLi
 
 	// Get HTTP Server
 	r := mux.NewRouter()
-	s := serviceList.GetHTTPServer(cfg.BindAddr, r)
+	s := serviceList.GetHTTPServer(cfg.BindAddr, cfg.HttpWriteTimeout, r)
 
 	// Get graphDB connection for observation store
 	graphDB, graphErrorConsumer, err := serviceList.GetGraphDB(ctx)

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/ONSdigital/dp-healthcheck/healthcheck"
 	"github.com/ONSdigital/dp-observation-api/api"
@@ -38,7 +39,7 @@ var funcDoGetHealthcheckErr = func(cfg *config.Config, buildTime string, gitComm
 	return nil, errHealthcheck
 }
 
-var funcDoGetHTTPServerNil = func(bindAddr string, router http.Handler) service.IServer {
+var funcDoGetHTTPServerNil = func(bindAddr string, httpWriteTimeout time.Duration, router http.Handler) service.IServer {
 	return nil
 }
 
@@ -80,7 +81,7 @@ func TestRunPrivate(t *testing.T) {
 			return hcMock, nil
 		}
 
-		funcDoGetHTTPServer := func(bindAddr string, router http.Handler) service.IServer {
+		funcDoGetHTTPServer := func(bindAddr string, httpWriteTimeout time.Duration, router http.Handler) service.IServer {
 			return serverMock
 		}
 
@@ -223,7 +224,7 @@ func TestRunPublic(t *testing.T) {
 			return hcMock, nil
 		}
 
-		funcDoGetHTTPServer := func(bindAddr string, router http.Handler) service.IServer {
+		funcDoGetHTTPServer := func(bindAddr string, httpWriteTimeout time.Duration, router http.Handler) service.IServer {
 			return serverMock
 		}
 
@@ -374,7 +375,9 @@ func TestClose(t *testing.T) {
 		Convey("Closing the service results in all the dependencies being closed in the expected order", func() {
 
 			initMock := &mock.InitialiserMock{
-				DoGetHTTPServerFunc: func(bindAddr string, router http.Handler) service.IServer { return serverMock },
+				DoGetHTTPServerFunc: func(bindAddr string, httpWriteTimeout time.Duration, router http.Handler) service.IServer {
+					return serverMock
+				},
 				DoGetGraphDBFunc: func(ctx context.Context) (api.IGraph, service.Closer, error) {
 					return graphDbMock, graphErrorConsumerMock, nil
 				},
@@ -406,7 +409,9 @@ func TestClose(t *testing.T) {
 			}
 
 			initMock := &mock.InitialiserMock{
-				DoGetHTTPServerFunc: func(bindAddr string, router http.Handler) service.IServer { return failingserverMock },
+				DoGetHTTPServerFunc: func(bindAddr string, httpWriteTimeout time.Duration, router http.Handler) service.IServer {
+					return failingserverMock
+				},
 				DoGetGraphDBFunc: func(ctx context.Context) (api.IGraph, service.Closer, error) {
 					return graphDbMock, graphErrorConsumerMock, nil
 				},


### PR DESCRIPTION
### What

- Make the HTTP write timeout value configurable  

Requests to the graph database can sometimes take a long time. It is not unusual to go beyond the default timeout of 10 seconds, which causes a timeout error to be returned. Allowing the value to be configurable makes it more flexible for the future.

- Prevent error from being masked by generic errs.ErrInternalServer

The default case sets err to the generic errs.ErrInternalServer err, which masks the original error detail and prevents it from being logged. The error is overwritten to prevent error details from being leaked into the HTTP response, but in doing so it prevents the original error data from being logged.

To prevent this I have introduced a new variable that maintains the error message to return in the HTTP response. This defaults to the error message, and only gets overwritten in the default case. Doing this prevents err from being overwritten allowing it to be logged.

### How to review
Review changes / tests

### Who can review
Anyone
